### PR TITLE
Fix service configuration

### DIFF
--- a/src/AuraConnect.Setup/Setup.iss
+++ b/src/AuraConnect.Setup/Setup.iss
@@ -19,7 +19,7 @@ Source: "..\bin\Release\netcoreapp3.1\win-x86\publish\**"; DestDir: "{app}"; Fla
 
 [Run]
 Filename: "{sys}\sc.exe"; Parameters: "create AuraConnect start=auto binpath=""{app}\AuraConnect.exe"""; StatusMsg: "Installing AURA Connect Service..."; Flags: runhidden
-Filename: "{sys}\sc.exe"; Parameters: "sc config AuraConnect depend=asComSvc/LightingService"; StatusMsg: "Configuring AURA Connect Service..."; Flags: runhidden
+Filename: "{sys}\sc.exe"; Parameters: "config AuraConnect depend=LightingService"; StatusMsg: "Configuring AURA Connect Service..."; Flags: runhidden
 Filename: "{sys}\sc.exe"; Parameters: "start AuraConnect"; StatusMsg: "Starting AURA Connect Service..."; Flags: runhidden
 
 [UninstallRun]


### PR DESCRIPTION
There is a typo that prevents setting dependencies, so AuraConnect fails to work sometimes. 
ASUS Com Service does not work at all on my setup (MacBook Pro 15" 2016, Razer Chroma X and ASUS Strix 5700XT), and it seems that is not needed at all.